### PR TITLE
Enable SERDES for Ethernet applications

### DIFF
--- a/M3-disable/SoftConsole_4.x-workspace/M3-Disable_M2S150-Adv-Dev-Kit_Enable-DDR/drivers_config/sys_config/sys_config.h
+++ b/M3-disable/SoftConsole_4.x-workspace/M3-Disable_M2S150-Adv-Dev-Kit_Enable-DDR/drivers_config/sys_config/sys_config.h
@@ -52,7 +52,7 @@
 #include "sys_config_SERDESIF_2.h"
 #endif
 
-#define MSS_SYS_SERDES_3_CONFIG_BY_CORTEX   0
+#define MSS_SYS_SERDES_3_CONFIG_BY_CORTEX   1
 #if MSS_SYS_SERDES_3_CONFIG_BY_CORTEX
 #include "sys_config_SERDESIF_3.h"
 #endif

--- a/M3-disable/SoftConsole_4.x-workspace/M3-Disable_M2S150-Adv-Dev-Kit_Enable-DDR/drivers_config/sys_config/sys_config_SERDESIF_3.c
+++ b/M3-disable/SoftConsole_4.x-workspace/M3-Disable_M2S150-Adv-Dev-Kit_Enable-DDR/drivers_config/sys_config/sys_config_SERDESIF_3.c
@@ -1,0 +1,37 @@
+/*=============================================================*/
+/* Created by Microsemi SmartDesign Mon May 08 19:13:33 2017   */
+/*                                                             */
+/* Warning: Do not modify this file, it may lead to unexpected */
+/*          functional failures in your design.                */
+/*                                                             */
+/*=============================================================*/
+
+/*-------------------------------------------------------------*/
+/* SERDESIF_3 Initialization                                   */
+/*-------------------------------------------------------------*/
+
+#include <stdint.h>
+#include "../../CMSIS/sys_init_cfg_types.h"
+
+const cfg_addr_value_pair_t g_m2s_serdes_3_config[] =
+{
+    { (uint32_t*)( 0x40034000 + 0x2028 ), 0x40F } /* SYSTEM_CONFIG_PHY_MODE_1 */ ,
+    { (uint32_t*)( 0x40034000 + 0x1998 ), 0x30 } /* LANE2_PHY_RESET_OVERRIDE */ ,
+    { (uint32_t*)( 0x40034000 + 0x1800 ), 0x80 } /* LANE2_CR0 */ ,
+    { (uint32_t*)( 0x40034000 + 0x1804 ), 0x20 } /* LANE2_ERRCNT_DEC */ ,
+    { (uint32_t*)( 0x40034000 + 0x1808 ), 0xF8 } /* LANE2_RXIDLE_MAX_ERRCNT_THR */ ,
+    { (uint32_t*)( 0x40034000 + 0x180c ), 0x80 } /* LANE2_IMPED_RATIO */ ,
+    { (uint32_t*)( 0x40034000 + 0x1814 ), 0x29 } /* LANE2_PLL_M_N */ ,
+    { (uint32_t*)( 0x40034000 + 0x1818 ), 0x20 } /* LANE2_CNT250NS_MAX */ ,
+    { (uint32_t*)( 0x40034000 + 0x1824 ), 0x80 } /* LANE2_TX_AMP_RATIO */ ,
+    { (uint32_t*)( 0x40034000 + 0x1828 ), 0x15 } /* LANE2_TX_PST_RATIO */ ,
+    { (uint32_t*)( 0x40034000 + 0x1830 ), 0x10 } /* LANE2_ENDCALIB_MAX */ ,
+    { (uint32_t*)( 0x40034000 + 0x1834 ), 0x38 } /* LANE2_CALIB_STABILITY_COUNT */ ,
+    { (uint32_t*)( 0x40034000 + 0x183c ), 0x70 } /* LANE2_RX_OFFSET_COUNT */ ,
+    { (uint32_t*)( 0x40034000 + 0x19d4 ), 0x2 } /* LANE2_GEN1_TX_PLL_CCP */ ,
+    { (uint32_t*)( 0x40034000 + 0x19d8 ), 0x22 } /* LANE2_GEN1_RX_PLL_CCP */ ,
+    { (uint32_t*)( 0x40034000 + 0x1998 ), 0x0 } /* LANE2_PHY_RESET_OVERRIDE */ ,
+    { (uint32_t*)( 0x40034000 + 0x1a00 ), 0x1 } /* LANE2_UPDATE_SETTINGS */ ,
+    { (uint32_t*)( 0x40034000 + 0x2028 ), 0xF0F } /* SYSTEM_CONFIG_PHY_MODE_1 */ 
+};
+

--- a/M3-disable/SoftConsole_4.x-workspace/M3-Disable_M2S150-Adv-Dev-Kit_Enable-DDR/drivers_config/sys_config/sys_config_SERDESIF_3.h
+++ b/M3-disable/SoftConsole_4.x-workspace/M3-Disable_M2S150-Adv-Dev-Kit_Enable-DDR/drivers_config/sys_config/sys_config_SERDESIF_3.h
@@ -1,0 +1,14 @@
+/*=============================================================*/
+/* Created by Microsemi SmartDesign Mon May 08 19:13:33 2017   */
+/*                                                             */
+/* Warning: Do not modify this file, it may lead to unexpected */
+/*          functional failures in your design.                */
+/*                                                             */
+/*=============================================================*/
+
+/*-------------------------------------------------------------*/
+/* SERDESIF_3 Initialization                                   */
+/*-------------------------------------------------------------*/
+
+#define SERDES_3_CFG_NB_OF_PAIRS 18u
+

--- a/M3-disable/SoftConsole_4.x-workspace/M3-Disable_M2S150-Adv-Dev-Kit_Enable-DDR/drivers_config/sys_config/sys_config_mss_clocks.h
+++ b/M3-disable/SoftConsole_4.x-workspace/M3-Disable_M2S150-Adv-Dev-Kit_Enable-DDR/drivers_config/sys_config/sys_config_mss_clocks.h
@@ -9,13 +9,13 @@
 #ifndef SYS_CONFIG_MSS_CLOCKS
 #define SYS_CONFIG_MSS_CLOCKS
 
-#define MSS_SYS_M3_CLK_FREQ             100000000u
-#define MSS_SYS_MDDR_CLK_FREQ           200000000u
-#define MSS_SYS_APB_0_CLK_FREQ          100000000u
-#define MSS_SYS_APB_1_CLK_FREQ          100000000u
-#define MSS_SYS_APB_2_CLK_FREQ          25000000u
-#define MSS_SYS_FIC_0_CLK_FREQ          100000000u
-#define MSS_SYS_FIC_1_CLK_FREQ          100000000u
-#define MSS_SYS_FIC64_CLK_FREQ          200000000u
+#define MSS_SYS_M3_CLK_FREQ             83000000u
+#define MSS_SYS_MDDR_CLK_FREQ           332000000u
+#define MSS_SYS_APB_0_CLK_FREQ          83000000u
+#define MSS_SYS_APB_1_CLK_FREQ          83000000u
+#define MSS_SYS_APB_2_CLK_FREQ          20750000u
+#define MSS_SYS_FIC_0_CLK_FREQ          83000000u
+#define MSS_SYS_FIC_1_CLK_FREQ          83000000u
+#define MSS_SYS_FIC64_CLK_FREQ          83000000u
 
 #endif /* SYS_CONFIG_MSS_CLOCKS */


### PR DESCRIPTION
Added sys_config_SERDESIF_3.c
Added sys_config_SERDESIF_3.h

Updated sys_config.h  ---   enable MSS_SYS_SERDES_3_CONFIG_BY_CORTEX

Updated sys_config_mss_clocks.h --- The current clock values (100MHz M3 clock)  don't seem correct.
updating the correct values. Generated these from "Modify_The_FPGA_Design" Libero project

Testing -- Verified that the example projects from 
RISCV-on-Microsemi-FPGA/SoftConsole/tree/master/ExampleWorkspace still work OK after adding this changes to M3-Disable_M2S150-Adv-Dev-Kit_Enable-DDR project.